### PR TITLE
Add firefox comparison

### DIFF
--- a/firefox/addon/README.md
+++ b/firefox/addon/README.md
@@ -1,0 +1,2 @@
+#Servo Performance Comparison
+Monitor website rendering performance

--- a/firefox/addon/data/perf.js
+++ b/firefox/addon/data/perf.js
@@ -1,11 +1,15 @@
+print = function(o) {
+    window.dump(o + '\n')
+}
+
 function formatLine(name, t){
   var output = "[PERF]," + name + "," + t;
-  console.log(output);
+  print(output);
   //document.getElementById('timing').innerHTML += output + "<br/>";
 }
 
 function printPerfTiming(){
-  console.log("[PERF] perf block start")
+  print("[PERF] perf block start")
   formatLine("testcase", window.location);
   formatLine("navigationStart", performance.timing.navigationStart);
   formatLine("unloadEventStart", performance.timing.unloadEventStart);
@@ -28,13 +32,17 @@ function printPerfTiming(){
   formatLine("domComplete", performance.timing.domComplete);
   formatLine("loadEventStart", performance.timing.loadEventStart);
   formatLine("loadEventEnd", performance.timing.loadEventEnd);
-  console.log("[PERF] perf block end")
+  print("[PERF] perf block end");
+  window.close()
 }
-window.addEventListener('load', printPerfTiming);
-var timeout = 5;
-window.setTimeout(function(){
-  console.log("[PERF] Timeout after " + timeout + " min. Force stop");
-  printPerfTiming();
-  window.close();
-}, timeout * 60 * 1000)
-
+if (document.readyState === "complete") { 
+    printPerfTiming()
+} else {
+    window.addEventListener('load', printPerfTiming);
+    var timeout = 5;
+    window.setTimeout(function(){
+        print("[PERF] Timeout after " + timeout + " min. Force stop");
+        printPerfTiming();
+        window.close();
+    }, timeout * 60 * 1000)
+}

--- a/firefox/addon/data/perf.js
+++ b/firefox/addon/data/perf.js
@@ -1,0 +1,40 @@
+function formatLine(name, t){
+  var output = "[PERF]," + name + "," + t;
+  console.log(output);
+  //document.getElementById('timing').innerHTML += output + "<br/>";
+}
+
+function printPerfTiming(){
+  console.log("[PERF] perf block start")
+  formatLine("testcase", window.location);
+  formatLine("navigationStart", performance.timing.navigationStart);
+  formatLine("unloadEventStart", performance.timing.unloadEventStart);
+  formatLine("unloadEventEnd", performance.timing.unloadEventEnd);
+  formatLine("redirectStart", performance.timing.redirectStart);
+  formatLine("redirectEnd", performance.timing.redirectEnd);
+  formatLine("fetchStart", performance.timing.fetchStart);
+  formatLine("domainLookupStart", performance.timing.domainLookupStart);
+  formatLine("domainLookupEnd", performance.timing.domainLookupEnd);
+  formatLine("connectStart", performance.timing.connectStart);
+  formatLine("connectEnd", performance.timing.connectEnd);
+  formatLine("secureConnectionStart", performance.timing.secureConnectionStart);
+  formatLine("requestStart", performance.timing.requestStart);
+  formatLine("responseStart", performance.timing.responseStart);
+  formatLine("responseEnd", performance.timing.responseEnd);
+  formatLine("domLoading", performance.timing.domLoading);
+  formatLine("domInteractive", performance.timing.domInteractive);
+  formatLine("domContentLoadedEventStart", performance.timing.domContentLoadedEventStart);
+  formatLine("domContentLoadedEventEnd", performance.timing.domContentLoadedEventEnd);
+  formatLine("domComplete", performance.timing.domComplete);
+  formatLine("loadEventStart", performance.timing.loadEventStart);
+  formatLine("loadEventEnd", performance.timing.loadEventEnd);
+  console.log("[PERF] perf block end")
+}
+window.addEventListener('load', printPerfTiming);
+var timeout = 5;
+window.setTimeout(function(){
+  console.log("[PERF] Timeout after " + timeout + " min. Force stop");
+  printPerfTiming();
+  window.close();
+}, timeout * 60 * 1000)
+

--- a/firefox/addon/index.js
+++ b/firefox/addon/index.js
@@ -1,0 +1,9 @@
+var self = require("sdk/self");
+var pageMod = require("sdk/page-mod");
+
+pageMod.PageMod({
+  include: "*",
+  contentScriptFile: self.data.url('perf.js'),
+  attachTo: ["top"],
+  contentScriptWhen: "start"
+});

--- a/firefox/addon/index.js
+++ b/firefox/addon/index.js
@@ -4,6 +4,5 @@ var pageMod = require("sdk/page-mod");
 pageMod.PageMod({
   include: "*",
   contentScriptFile: self.data.url('perf.js'),
-  attachTo: ["top"],
-  contentScriptWhen: "start"
+  attachTo: ["top", "existing"]
 });

--- a/firefox/addon/package.json
+++ b/firefox/addon/package.json
@@ -1,0 +1,16 @@
+{
+  "title": "Servo Performance Comparison",
+  "name": "addon",
+  "version": "0.0.1",
+  "description": "Monitor website rendering performance",
+  "main": "index.js",
+  "author": "The Servo team",
+  "engines": {
+    "firefox": ">=38.0a1",
+    "fennec": ">=38.0a1"
+  },
+  "license": "MPL",
+  "keywords": [
+    "jetpack"
+  ]
+}

--- a/firefox/addon/test/test-index.js
+++ b/firefox/addon/test/test-index.js
@@ -1,0 +1,3 @@
+var main = require("../");
+
+require("sdk/test").run(exports);


### PR DESCRIPTION
- [x] page-mod addon that prints performance data to stdout written
- [x] integrated firefox with current test runner
- [ ] submit firefox data to perfherder

Right now I'm not particularly happy with having the performance JS in two places, but I'm not sure an addon can use scripts from outside it's directory, and even if it could, I'm not sure that's very clean.
