### PR TITLE
Remove link to servo from treeherder job details

### DIFF
--- a/submit_to_perfherder.py
+++ b/submit_to_perfherder.py
@@ -311,12 +311,6 @@ def submit(perf_data, failures, revision, summary, engine):
                         "blob": {
                             "job_details": [
                                 {
-                                    "content_type": "link",
-                                    "url": "https://www.github.com/servo/servo",
-                                    "value": "GitHub",
-                                    "title": "Source code"
-                                },
-                                {
                                     "content_type": "raw_html",
                                     "title": "Result Summary",
                                     "value": summary


### PR DESCRIPTION
The servo repository is already linked to from the revision list, there is no need for each job to link to it as well.

This came up in: https://bugzilla.mozilla.org/show_bug.cgi?id=1342296